### PR TITLE
Use assignRole in flexible User example

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -124,9 +124,12 @@ interface:
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Konekt\User\Contracts\Profile;
 use Konekt\User\Contracts\User as UserContract;
+use Konekt\Acl\Traits\HasRoles;
 
 class User extends Authenticatable implements UserContract
 {
+    use HasRoles;
+    
     // ...
     
     // Implement these methods from the required Interface:


### PR DESCRIPTION
Fix for `Call to undefined method App\Models\User::assignRole()` during `php artisan make:superuser ` when using flexible User example.